### PR TITLE
Update aeson max version

### DIFF
--- a/wai-middleware-rollbar.cabal
+++ b/wai-middleware-rollbar.cabal
@@ -19,7 +19,7 @@ library
   exposed-modules:     Network.Wai.Middleware.Rollbar
                      , Network.Wai.Middleware.Rollbar.Payload
   build-depends:       base >= 4.9 && < 5
-                     , aeson >= 1.0 && < 1.3
+                     , aeson >= 1.0 && < 1.4
                      , bytestring >= 0.10 && < 0.11
                      , hostname >= 1.0 && < 1.1
                      , http-client >= 0.5 && < 0.6


### PR DESCRIPTION
Unable to use this with the stack lts-12.x due to a version mismatch.  