### PR TITLE
Make it lts-12.10 compatible

### DIFF
--- a/stack.yaml
+++ b/stack.yaml
@@ -1,7 +1,7 @@
 flags: {}
 extra-package-dbs: []
 packages:
-- .
+  - .
 extra-deps:
-- rollbar-hs-0.1.0.1
-resolver: nightly-2017-11-25
+  - rollbar-hs-0.3.1.0
+resolver: lts-12.10


### PR DESCRIPTION
Making this lts-12.10 compatible.

I'm not sure if we should have bumped the lts in the `stack.yaml` too. Does this make the package less compatible with folks in older codebases?