### PR TITLE
Bump version to 0.11.0

### DIFF
--- a/wai-middleware-rollbar.cabal
+++ b/wai-middleware-rollbar.cabal
@@ -1,5 +1,5 @@
 name:                wai-middleware-rollbar
-version:             0.10.0
+version:             0.11.0
 synopsis:            Middleware that communicates to Rollbar.
 description:         Middleware that communicates to Rollbar.
 homepage:            https://github.com/joneshf/wai-middleware-rollbar#readme


### PR DESCRIPTION
Relaxing the upper bound for aeson moved through a breaking change.
That change had to do with removing constraints and whatever.
This might not be a real breaking change, but better to be safe than sorry.